### PR TITLE
Fixed pasted text scrolling problem.

### DIFF
--- a/web/src/main/java/com/mysticcoders/mysticpaste/web/components/highlighter/shThemeDefault.css
+++ b/web/src/main/java/com/mysticcoders/mysticpaste/web/components/highlighter/shThemeDefault.css
@@ -16,6 +16,7 @@
  */
 .syntaxhighlighter {
   background-color: white !important;
+  padding-bottom: 1px !important;
 }
 .syntaxhighlighter .line.alt1 {
   background-color: white !important;


### PR DESCRIPTION
The pasted text was intercepting the mouse scroll on a page, making it difficult to scroll down a long paste.

This was fixed by adding 1 pixel of padding to the bottom of the syntaxhighlighter class in the css file "shThemeDefault.css".
