### PR TITLE
Replace the usage of System.out or System.err by a logger

### DIFF
--- a/eclipse-plugin/src/com/mysticcoders/mysticpaste/Activator.java
+++ b/eclipse-plugin/src/com/mysticcoders/mysticpaste/Activator.java
@@ -3,6 +3,8 @@ package com.mysticcoders.mysticpaste;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The activator class controls the plug-in life cycle
@@ -12,6 +14,8 @@ import org.osgi.framework.BundleContext;
  */
 public class Activator extends AbstractUIPlugin {
 
+	private final Logger logger = LoggerFactory.getLogger(getClass());
+	
 	// The plug-in ID
 	public static final String PLUGIN_ID = "com.mysticcoders.mysticpaste";
 
@@ -31,7 +35,7 @@ public class Activator extends AbstractUIPlugin {
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
 		plugin = this;
-		System.out.println("Plugin Started");
+		logger.info("Plugin Started");
 	}
 
 	/*

--- a/eclipse-plugin/src/com/mysticcoders/mysticpaste/popup/actions/MysticPasteAction.java
+++ b/eclipse-plugin/src/com/mysticcoders/mysticpaste/popup/actions/MysticPasteAction.java
@@ -32,6 +32,8 @@ import org.eclipse.swt.widgets.ToolTip;
 import org.eclipse.ui.IEditorActionDelegate;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.texteditor.ITextEditor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implements an Action Delegate which responds to a context menu item click<br/>
@@ -44,6 +46,8 @@ import org.eclipse.ui.texteditor.ITextEditor;
  */
 public class MysticPasteAction implements IEditorActionDelegate {
 
+	private static final Logger logger = LoggerFactory.getLogger(MysticPasteAction.class);
+	
 	private String selectionText = null;
 	private String fileExtension = null;
 	private Shell shell;
@@ -66,7 +70,7 @@ public class MysticPasteAction implements IEditorActionDelegate {
 	 * balloon tip.
 	 */
 	public void run(IAction action) {
-		System.out.println("run called");
+		logger.debug("run called");
 		if (this.selectionText != null && !this.selectionText.trim().equals("")) {
 			//the action is setup in plugin.xml with an ID that ends in .<lang type>
 			String type = action.getId().substring(action.getId().lastIndexOf('.') + 1);
@@ -85,7 +89,7 @@ public class MysticPasteAction implements IEditorActionDelegate {
 	 * first time, so you can never grey out the item before it is clicked. 
 	 */
 	public void selectionChanged(IAction action, ISelection selection) {
-		System.out.println("selectionChanged called");
+		logger.debug("selectionChanged called");
 		if (ITextSelection.class.isAssignableFrom(selection.getClass())) {
 			ITextSelection txtSelection = (ITextSelection) selection;
 			if (txtSelection == null || txtSelection.isEmpty() || txtSelection.getText().trim().equals("")) {
@@ -136,7 +140,7 @@ public class MysticPasteAction implements IEditorActionDelegate {
 			HttpEntity entity = response.getEntity();
 			retString = EntityUtils.toString(entity, HTTP.UTF_8);
 			retString = url + bundle.getString("mysticpaste.view") + retString;
-			System.out.println(retString);
+			logger.debug(retString);
 		} catch (ClientProtocolException e) {
 			e.printStackTrace();
 			MessageDialog.openInformation(

--- a/web/src/main/java/com/mysticcoders/mysticpaste/model/PasteItem.java
+++ b/web/src/main/java/com/mysticcoders/mysticpaste/model/PasteItem.java
@@ -6,6 +6,8 @@ import org.bson.types.ObjectId;
 import org.incava.util.diff.Diff;
 import org.incava.util.diff.Difference;
 import org.msgpack.annotation.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
@@ -20,7 +22,7 @@ import java.util.*;
 @Message
 public class PasteItem implements Serializable {
     private static final long serialVersionUID = -6467870857777145137L;
-
+    private static Logger logger = LoggerFactory.getLogger(PasteItem.class);
     private static SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy");
 
     @Id ObjectId id;
@@ -164,8 +166,8 @@ public class PasteItem implements Serializable {
         int new_line_count = 0;
         int old_line_count = 0;
 
-        System.out.println("Original: " + (originalPaste != null ? originalPaste.length() : 0) + " line(s)");
-        System.out.println("Revised: " + (revisedPaste != null ? revisedPaste.length() : 0) + " line(s)");
+        logger.info("Original: " + (originalPaste != null ? originalPaste.length() : 0) + " line(s)");
+        logger.info("Revised: " + (revisedPaste != null ? revisedPaste.length() : 0) + " line(s)");
 
         List<String> original = Arrays.asList(originalPaste.split("\n"));
         List<String> revised = Arrays.asList(revisedPaste.split("\n"));

--- a/web/src/main/java/com/mysticcoders/mysticpaste/persistence/mongo/PasteItemDaoImpl.java
+++ b/web/src/main/java/com/mysticcoders/mysticpaste/persistence/mongo/PasteItemDaoImpl.java
@@ -70,10 +70,10 @@ public class PasteItemDaoImpl implements PasteItemDao {
             ds.insert(item);
 
             if(!item.isPrivate()) {
-                System.out.println("ITEM IS NOT PRIVATE");
+                logger.info("ITEM IS NOT PRIVATE");
                 jedis.lpush("pasteHistory", "" + pasteIndex);
                 byte[] packedEntry = packEntry(item);
-                System.out.println(new String(packedEntry));
+                logger.info(new String(packedEntry));
                 jedis.rpop("pasteHistoryCache".getBytes());
                 jedis.lpush("pasteHistoryCache".getBytes(), packedEntry);
             }
@@ -296,7 +296,7 @@ public class PasteItemDaoImpl implements PasteItemDao {
 
             PasteItem modifiedPasteItem = ds.findAndModify(query, updateOp);
             if (modifiedPasteItem.getAbuseCount() > 1) {
-                System.out.println("Removing paste [" + modifiedPasteItem.getItemId() + "] because of abuseCount:" + modifiedPasteItem.getAbuseCount());
+                logger.info("Removing paste [" + modifiedPasteItem.getItemId() + "] because of abuseCount:" + modifiedPasteItem.getAbuseCount());
                 jedis.lrem("pasteHistory", 1, "" + modifiedPasteItem.getPasteIndex());
             }
         } catch (JedisConnectionException je) {
@@ -321,7 +321,7 @@ public class PasteItemDaoImpl implements PasteItemDao {
 
             PasteItem modifiedPasteItem = ds.findAndModify(query, updateOp);
             if (modifiedPasteItem.getAbuseCount() > 1) {
-                System.out.println("Restoring paste [" + modifiedPasteItem.getItemId() + "] because of abuseCount:" + modifiedPasteItem.getAbuseCount());
+                logger.info("Restoring paste [" + modifiedPasteItem.getItemId() + "] because of abuseCount:" + modifiedPasteItem.getAbuseCount());
 // TODO figure out how we can fix the list and how to include the paste in the proper spot
 //                redisTemplate.opsForList().
 //                redisTemplate.opsForList().remove("pasteHistory", 1, "" + modifiedPasteItem.getPasteIndex());

--- a/web/src/main/java/com/mysticcoders/mysticpaste/web/pages/history/HistoryPage.java
+++ b/web/src/main/java/com/mysticcoders/mysticpaste/web/pages/history/HistoryPage.java
@@ -120,7 +120,7 @@ public class HistoryPage extends BasePage {
         final AbstractDefaultAjaxBehavior historyNextPageNav = new AbstractDefaultAjaxBehavior() {
             @Override
             protected void respond(AjaxRequestTarget target) {
-                System.out.println("Next Page");
+                logger.info("Next Page");
                 if (pageNav.getPageable().getCurrentPage() < pageNav.getPageable().getPageCount() - 1) {
                     pageNav.getPageable().setCurrentPage(pageNav.getPageable().getCurrentPage() + 1);
                     target.add(historyDataViewContainer, pageNav, pageNav2);
@@ -130,7 +130,7 @@ public class HistoryPage extends BasePage {
         final AbstractDefaultAjaxBehavior historyPrevPageNav = new AbstractDefaultAjaxBehavior() {
             @Override
             protected void respond(AjaxRequestTarget target) {
-                System.out.println("Previous Page");
+                logger.info("Previous Page");
                 if (pageNav.getPageable().getCurrentPage() > 0) {
                     pageNav.getPageable().setCurrentPage(pageNav.getPageable().getCurrentPage() - 1);
                     target.add(historyDataViewContainer, pageNav, pageNav2);
@@ -140,7 +140,7 @@ public class HistoryPage extends BasePage {
         final AbstractDefaultAjaxBehavior historyFirstPageNav = new AbstractDefaultAjaxBehavior() {
             @Override
             protected void respond(AjaxRequestTarget target) {
-                System.out.println("First Page");
+                logger.info("First Page");
                 if (pageNav.getPageable().getCurrentPage() > 1) {
                     pageNav.getPageable().setCurrentPage(0);
                     target.add(historyDataViewContainer, pageNav, pageNav2);
@@ -150,7 +150,7 @@ public class HistoryPage extends BasePage {
         final AbstractDefaultAjaxBehavior historyLastPageNav = new AbstractDefaultAjaxBehavior() {
             @Override
             protected void respond(AjaxRequestTarget target) {
-                System.out.println("Last Page");
+                logger.info("Last Page");
                 if (pageNav.getPageable().getCurrentPage() < pageNav.getPageable().getPageCount() - 1) {
                     pageNav.getPageable().setCurrentPage(pageNav.getPageable().getPageCount() - 1);
                     target.add(historyDataViewContainer, pageNav, pageNav2);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S106 - “Standard outputs should not be used directly to log anything”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S106
Please let me know if you have any questions.
Ayman Abdelghany.