### PR TITLE
Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/web/src/main/java/com/mysticcoders/mysticpaste/MysticPasteApplication.java
+++ b/web/src/main/java/com/mysticcoders/mysticpaste/MysticPasteApplication.java
@@ -136,7 +136,7 @@ public class MysticPasteApplication extends WebApplication {
     }
 
     public static MysticPasteApplication getInstance() {
-        return ((MysticPasteApplication) WebApplication.get());
+        return (MysticPasteApplication) WebApplication.get();
     }
 
     public Class<PasteItemPage> getHomePage() {

--- a/web/src/main/java/com/mysticcoders/mysticpaste/services/PasteServiceImpl.java
+++ b/web/src/main/java/com/mysticcoders/mysticpaste/services/PasteServiceImpl.java
@@ -94,7 +94,7 @@ public class PasteServiceImpl implements PasteService {
     }
 
     public boolean twitterEnabled() {
-        return (twitterEnabled != null) && Boolean.valueOf(twitterEnabled);
+        return twitterEnabled != null && Boolean.valueOf(twitterEnabled);
     }
 
     public void setTwitterEnabled(String twitterEnabled) {

--- a/web/src/main/java/com/mysticcoders/mysticpaste/web/pages/BasePage.java
+++ b/web/src/main/java/com/mysticcoders/mysticpaste/web/pages/BasePage.java
@@ -200,7 +200,7 @@ public class BasePage extends WebPage {
      * @return
      */
     protected String getClientIpAddress() {
-        ServletWebRequest request = ((ServletWebRequest) RequestCycle.get().getRequest());
+        ServletWebRequest request = (ServletWebRequest) RequestCycle.get().getRequest();
         String ipAddress = request.getHeader("X-Forwarded-For");
         if (ipAddress == null) {
             ipAddress = request.getContainerRequest().getRemoteHost();
@@ -209,7 +209,7 @@ public class BasePage extends WebPage {
     }
 
     protected String getReferrer() {
-        ServletWebRequest request = ((ServletWebRequest) RequestCycle.get().getRequest());
+        ServletWebRequest request = (ServletWebRequest) RequestCycle.get().getRequest();
 
         return request.getHeader("referer");
     }

--- a/web/src/main/java/com/mysticcoders/mysticpaste/web/pages/view/ViewPastePage.java
+++ b/web/src/main/java/com/mysticcoders/mysticpaste/web/pages/view/ViewPastePage.java
@@ -110,7 +110,7 @@ public abstract class ViewPastePage extends BasePage {
         }
 
         pasteModel = getPasteModel(params.get("0").toString());
-        if (pasteModel.getObject() == null || (pasteModel.getObject().isPrivate() && params.get("0").isNull())) {
+        if (pasteModel.getObject() == null || pasteModel.getObject().isPrivate() && params.get("0").isNull()) {
             throw new RestartResponseException(PasteNotFound.class);
         }
         if (pasteModel.getObject().getAbuseCount() > 2) {
@@ -156,7 +156,7 @@ public abstract class ViewPastePage extends BasePage {
             PasteItem parentPaste = pasteService.getItem(pasteModel.getObject().getParent());
             PageParameters pp = new PageParameters();
             pp.add("0", parentPaste.getItemId());
-            diffView.add(new BookmarkablePageLink<Void>("originalPasteLink", (parentPaste.isPrivate() ? ViewPrivatePage.class : ViewPublicPage.class), pp));
+            diffView.add(new BookmarkablePageLink<Void>("originalPasteLink", parentPaste.isPrivate() ? ViewPrivatePage.class : ViewPublicPage.class, pp));
 
 
             Object[] diffOutput = PasteItem.diffPastes(parentPaste.getContent(), pasteModel.getObject().getContent());
@@ -192,7 +192,7 @@ public abstract class ViewPastePage extends BasePage {
 
                 PageParameters pp = new PageParameters();
                 pp.add("0", pasteItem.getItemId());
-                BookmarkablePageLink<Void> viewPaste = new BookmarkablePageLink<Void>("viewChildPaste", (pasteItem.isPrivate() ? ViewPrivatePage.class : ViewPublicPage.class), pp);
+                BookmarkablePageLink<Void> viewPaste = new BookmarkablePageLink<Void>("viewChildPaste", pasteItem.isPrivate() ? ViewPrivatePage.class : ViewPublicPage.class, pp);
 
                 viewPaste.add(new Label("pasteId", new PropertyModel<String>(item.getModel(), "itemId")));
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.